### PR TITLE
Vercel Blob に Todo リストを永続化する Fixes #16

### DIFF
--- a/api/save-blob.ts
+++ b/api/save-blob.ts
@@ -9,16 +9,14 @@ export default async function handler(
     if (req.method !== "POST") {
       return res.status(405).json({ error: "Method not allowed" });
     }
-    console.debug("body: ", req.body);
     const { key, value } = req.body;
-    console.debug("key: ", key);
-    console.debug("value:" , value);
     if (!key || typeof value !== "string") {
       return res.status(400).json({ error: "Invalid input" });
     }
     const result = await put(key, value, {
       access: "public",
       addRandomSuffix: false,
+      cacheControlMaxAge: 0,
     });
     console.debug("result: ", result);
     return res.status(200).json({ url: result.url });

--- a/src/storage/VercelBlobStorage.ts
+++ b/src/storage/VercelBlobStorage.ts
@@ -3,7 +3,6 @@ import { StorageKey, IStorage } from "@/interfaces";
 class VercelBlobStorage implements IStorage {
   async save(key: StorageKey, value: string): Promise<void> {
     const body = JSON.stringify({ key: key.name, value });
-    console.log("body: ", body);
     await fetch("/api/save-blob", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -14,13 +13,8 @@ class VercelBlobStorage implements IStorage {
   async load(key: StorageKey): Promise<string | null> {
     const res = await fetch("/api/head-blob?key=" + key.name);
     const { url } = await res.json();
-    const downloadUrl = `${url}?ts=${Date.now()}`;
-    console.log("downloadUrl: ", downloadUrl);
-    const response = await fetch(downloadUrl);
-    console.log("response: ", response);
-    const value = await response.text();
-    console.log("downloaded value:", value);
-    return value;
+    const response = await fetch(url);
+    return response.text();
   }
 
   async remove(key: StorageKey): Promise<void> {


### PR DESCRIPTION
Fixes #16

#49 と同じ内容だが、対策内容に一部不備があったため、再対策を行なった。

## ✅ Vercel Blob 対応の実装内容と経緯まとめ

このPRでは、Todoリストのデータを Vercel Blob に永続化できるようにし、保存対象をローカルストレージから切り替え可能な構成に移行しました。以下にその概要をまとめます。

---

### 🔧 背景と課題

従来の実装では、データの保存先として `localStorage` を利用していましたが、将来的に **クラウドストレージ対応（例：Vercel Blob）** を見据え、保存先を抽象化して切り替え可能にしたいという意図がありました。

ただし、Vercel Blob はブラウザから直接操作すると CORS 制限により問題が発生すること、また SDK が ESM に依存していることなど、いくつかの技術的ハードルがありました。

---

### ✨ 対応内容の詳細

#### 1. API Routes 経由で Blob にアクセス
CORS 問題を回避するため、クライアントから直接 SDK を使うのではなく、以下の **API Route** を用意しました：

- `/api/save-blob`（`put()`）
- `/api/head-blob`（`head()` + ダウンロードURL取得）
- `/api/delete-blob`（`del()`）

Blob キー名はクエリ or POST body 経由で受け取り、ファイル名として利用しています。

---

#### 2. package.json に `"type": "module"` を追加
Blob SDK が ESM に対応しているため、API Route で import を使うには、
```json
"type": "module"
```
の追加が必須でした。これにより、Edge Function を使わずに Serverless Function 上で `import { put } from "@vercel/blob"` を利用可能にしました。

---

#### 3. `VercelBlobStorage` の実装
共通の `IStorage` インタフェースに準拠し、Blob API を叩くクラスを新設：
```ts
class VercelBlobStorage implements IStorage {
  save(key, value)   // POST /api/save-blob
  load(key)          // GET  /api/head-blob → download URL → fetch()
  remove(key)        // GET  /api/delete-blob
}
```

---

#### 4. `TodoList` 側の対応（ロード状態管理）
非同期ロードを考慮し、`loaded` ステートを導入：
- 読み込み中は `"読み込み中..."` のみを表示
- ロード完了前には `save()` を実行しない（初期化時のデータが空配列として上書きされるのを防止）

これにより、**空のTodoリストで既存データを消してしまう問題** を解消しました。

---

#### 5. テストコードの対応
`loaded` が切り替わるまでUIの検査を待機するように変更：

```ts
await screen.findByText("追加");
```

これにより、非同期読み込み完了後のUIに対して安定してテストを実行できます。

---

#### 6. 環境変数対応 (`vite.config.ts`)
Blob API の動作に必要な環境変数（自動設定）を認識させるため、Vite 設定に次を追加：

```ts
define: {
  "process.env": process.env
}
```
---

#### 7. ダウンロード時のキャッシュ回避対策（重要）

~~Blob API で取得した **ダウンロードURL** は CDN 経由で提供されており、同一URLに対するリクエストでは **古い内容が返される** ことがあります（キャッシュが効いてしまうため）。~~

~~これにより、Blob を更新しても直後に取得すると古い内容が返されてしまい、**保存ができていても読み出しが正しく行われない** 状況が発生していました。~~

~~✅ 対応策：~~
```ts
const response = await fetch(`${downloadUrl}?t=${Date.now()}`);
```

~~URLに適当な **タイムスタンプクエリを付与することでキャッシュをバイパス**し、常に最新の内容が取得できるようにしました。~~

この方法では回避できない。
https://vercel.com/docs/vercel-blob#caching
> You can configure this caching behavior by using the cacheControlMaxAge option on the [put()](https://vercel.com/docs/storage/vercel-blob/using-blob-sdk#put) method.
>
>The minimum value is 0 second for browser and edge cache. The maximum value is 5 minutes (300 seconds) for edge cache and unlimited for browser cache.
>
>The query string on the blob URL is not part of the cache key, meaning you cannot bypass the cache by adding a unique query string to the URL.

`put`する際に、`cacheControlMaxAge=0`を指定することで、キャッシュの寿命が0秒になり、事実上、キャッシュが無効になる。

---

### ✅ 結果と学び

- CORS対策としての API Route 経由アクセスは有効
- Blob の内容が即時反映されない場合があり、キャッシュ（CDN）を考慮する必要がある
- 非同期ロードはUIとテスト両方に明示的に対処が必要
- `useEffect` によるストレージ初期化は、競合によって思わぬ副作用が起き得るため注意が必要

---

以上です！レビューよろしくお願いいたします 🙇‍♂️

