### PR TITLE
実行環境に応じて使用するストレージ（LocalStorage / VercelBlobStorage）を切り替える

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,15 @@
 import { Counter, TodoList } from "@/components";
-import { LocalStorage, VercelBlobStorage } from "./storage";
+import { getStorage, LocalStorage } from "./storage";
 
 function App() {
+  const cloudStorage = getStorage();
+ 
   return (
     <div>
       <h1>マイアプリ</h1>
-      <TodoList storage={new VercelBlobStorage()} />
+      <TodoList storage={cloudStorage} />
       <Counter title="カウンター1" storage={new LocalStorage()} />
-    </div>
+      </div>
   );
 }
 

--- a/src/storage/getStorage.test.ts
+++ b/src/storage/getStorage.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getStorage } from './getStorage';
+import LocalStorage from './LocalStorage';
+import VercelBlobStorage from './VercelBlobStorage';
+import * as env from '@/utils/env';
+
+// isProduction 関数をモック
+vi.mock('@/utils/env', () => ({
+    isProduction: vi.fn()
+}));
+
+describe('getStorage', () => {
+    beforeEach(() => {
+        // テスト前にモックをリセット
+        vi.resetAllMocks();
+    });
+
+    it('本番環境では VercelBlobStorage を返す', () => {
+        // isProduction を true に設定
+        vi.mocked(env.isProduction).mockReturnValue(true);
+
+        const storage = getStorage();
+        expect(storage).toBeInstanceOf(VercelBlobStorage);
+    });
+
+    it('開発環境では LocalStorage を返す', () => {
+        // isProduction を false に設定
+        vi.mocked(env.isProduction).mockReturnValue(false);
+
+        const storage = getStorage();
+        expect(storage).toBeInstanceOf(LocalStorage);
+    });
+}); 

--- a/src/storage/getStorage.ts
+++ b/src/storage/getStorage.ts
@@ -1,0 +1,18 @@
+import { IStorage } from '@/interfaces';
+import LocalStorage from './LocalStorage';
+import VercelBlobStorage from './VercelBlobStorage';
+import { isProduction } from '@/utils/env';
+
+/**
+ * 環境に応じて適切なストレージ実装を返す
+ * @returns IStorage の実装インスタンス
+ */
+export function getStorage(): IStorage {
+  // 本番環境では VercelBlobStorage を使用
+  if (isProduction()) {
+    return new VercelBlobStorage();
+  }
+
+  // それ以外（development, preview）では LocalStorage を使用
+  return new LocalStorage();
+} 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,3 +1,3 @@
 export { default as LocalStorage } from "./LocalStorage";
 export { default as MemoryStorage } from "./MemoryStorage";
-export { default as VercelBlobStorage } from "./VercelBlobStorage";
+export { getStorage } from "./getStorage";

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_VERCEL_ENV: 'development' | 'preview' | 'production'
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+} 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,14 @@
+/**
+ * 現在の環境が本番環境かどうかを判定する
+ * 
+ * Vercel上で実行される場合、Viteは自動的に以下の環境変数を設定します：
+ * - import.meta.env.VITE_VERCEL_ENV: 'development' | 'preview' | 'production'
+ * 
+ * 本番環境（production）では、この値が'production'になります。
+ * 開発環境やプレビュー環境では、それぞれ'development'または'preview'になります。
+ * 
+ * @returns 本番環境の場合は true、それ以外の場合は false
+ */
+export function isProduction(): boolean {
+    return import.meta.env.VITE_VERCEL_ENV === 'production';
+} 


### PR DESCRIPTION
Fixes #52

## 環境に応じたストレージ実装の切り替え機能の実装

### 概要
本番環境では VercelBlobStorage を使用し、それ以外（ローカル開発／プレビュー環境）では LocalStorage を使用するように、IStorage 実装の選択を環境に応じて切り替える機能を実装しました。

### 変更内容
1. `src/storage/getStorage.ts` の新規作成
   - 環境に応じて適切なストレージ実装を返す関数を実装
   - 本番環境では VercelBlobStorage、それ以外では LocalStorage を返す

2. `src/utils/env.ts` の新規作成
   - 環境判定のためのユーティリティ関数を実装
   - Vercelの環境変数（VITE_VERCEL_ENV）に基づいて本番環境を判定

3. `src/App.tsx` の修正
   - TodoList コンポーネントには `getStorage()` を使用
   - Counter コンポーネントには LocalStorage を直接使用（クラウド永続化不要）

4. `src/storage/getStorage.test.ts` の新規作成
   - 環境に応じたストレージ実装の切り替えをテスト
   - isProduction 関数のモックを使用して各環境をシミュレート

### 動作確認
- ローカル開発環境：LocalStorage が使用されることを確認
- プレビュー環境：LocalStorage が使用されることを確認
- 本番環境：VercelBlobStorage が使用されることを確認

### 補足
- Vercel上では、Viteが自動的に `VITE_VERCEL_ENV` 環境変数を設定します
- 本番環境では 'production'、開発環境では 'development'、プレビュー環境では 'preview' の値が設定されます
- Counter コンポーネントは永続化が不要なため、常に LocalStorage を使用します

### 今後の改善点

- [ ] ストレージ実装の選択ロジックの拡張性
   - 現在は本番環境かどうかの二択ですが、より細かい環境（staging, testing など）に対応
   - 環境変数による設定オプションの追加（例：`VITE_STORAGE_TYPE=local` で強制的に LocalStorage を使用）
- [ ] エラーハンドリングの強化
   - ストレージ操作時のエラー処理の統一化
   - エラー発生時のフォールバックメカニズムの実装
   - ユーザーへのエラー通知機能の追加
- [ ] パフォーマンス最適化
   - ストレージインスタンスのシングルトン化（不要な再インスタンス化の防止）
   - キャッシュ層の追加（頻繁なストレージアクセスの最適化）
- [ ] テストの拡充
   - エラーケースのテスト追加
   - パフォーマンステストの追加
   - E2Eテストでのストレージ切り替えの検証
- [ ] モニタリングとデバッグ
   - 使用中のストレージ実装のログ出力
   - ストレージ操作のパフォーマンスメトリクス収集
   - デバッグモードでの詳細情報表示
- [ ] ドキュメント整備
   - 各ストレージ実装の特徴と使用場面の説明
   - 環境変数設定の詳細なドキュメント
   - トラブルシューティングガイドの作成